### PR TITLE
chore(cdnAddress): update cdn address to point to localhost

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`one-app-dev-cdn module-map.json extends the remote map with the local map 1`] = `"{\\"key\\":\\"not-used-in-development\\",\\"modules\\":{\\"module-b\\":{\\"node\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js\\",\\"integrity\\":\\"345\\"}},\\"module-a\\":{\\"node\\":{\\"url\\":\\"https://example.com/cdn/module-a/1.0.0/module-a.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"https://example.com/cdn/module-a/1.0.0/module-a.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"https://example.com/cdn/module-a/1.0.0/module-a.legacy.browser.js\\",\\"integrity\\":\\"345\\"}}}}"`;
+exports[`one-app-dev-cdn module-map.json extends the remote map with the local map 1`] = `"{\\"key\\":\\"not-used-in-development\\",\\"modules\\":{\\"module-b\\":{\\"node\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js\\",\\"integrity\\":\\"345\\"}},\\"module-a\\":{\\"node\\":{\\"url\\":\\"https://example.com/cdn/module-a/1.0.0/module-a.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"https://example.com/cdn/module-a/1.0.0/module-a.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"https://example.com/cdn/module-a/1.0.0/module-a.legacy.browser.js\\",\\"integrity\\":\\"345\\"}}}}"`;
 
 exports[`one-app-dev-cdn module-map.json uses the local map overriding the cdn url placeholder with the one-app-dev-cdn url 1`] = `
 Object {
@@ -24,7 +24,7 @@ Object {
 }
 `;
 
-exports[`one-app-dev-cdn modules gets remote modules: module map response 1`] = `"{\\"key\\":\\"not-used-in-development\\",\\"modules\\":{\\"module-b\\":{\\"node\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js\\",\\"integrity\\":\\"345\\"}}}}"`;
+exports[`one-app-dev-cdn modules gets remote modules: module map response 1`] = `"{\\"key\\":\\"not-used-in-development\\",\\"modules\\":{\\"module-b\\":{\\"node\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js\\",\\"integrity\\":\\"345\\"}}}}"`;
 
 exports[`one-app-dev-cdn modules gets remote modules: module response 1`] = `
 Array [
@@ -62,7 +62,7 @@ Array [
 ]
 `;
 
-exports[`one-app-dev-cdn modules returns a 404 if a request for something not known as a module from the module map comes in: module map response 1`] = `"{\\"key\\":\\"not-used-in-development\\",\\"modules\\":{\\"module-b\\":{\\"node\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js\\",\\"integrity\\":\\"345\\"}}}}"`;
+exports[`one-app-dev-cdn modules returns a 404 if a request for something not known as a module from the module map comes in: module map response 1`] = `"{\\"key\\":\\"not-used-in-development\\",\\"modules\\":{\\"module-b\\":{\\"node\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js\\",\\"integrity\\":\\"345\\"}}}}"`;
 
 exports[`one-app-dev-cdn modules returns a 404 if a request for something not known as a module from the module map comes in: remote calls from got 1`] = `
 Array [
@@ -83,7 +83,7 @@ Array [
 ]
 `;
 
-exports[`one-app-dev-cdn modules returns a 500 if a request to proxy a module from the module map fails: module map response 1`] = `"{\\"key\\":\\"not-used-in-development\\",\\"modules\\":{\\"module-b\\":{\\"node\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js\\",\\"integrity\\":\\"345\\"}}}}"`;
+exports[`one-app-dev-cdn modules returns a 500 if a request to proxy a module from the module map fails: module map response 1`] = `"{\\"key\\":\\"not-used-in-development\\",\\"modules\\":{\\"module-b\\":{\\"node\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.node.js\\",\\"integrity\\":\\"123\\"},\\"browser\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.browser.js\\",\\"integrity\\":\\"234\\"},\\"legacyBrowser\\":{\\"url\\":\\"http://localhost:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js\\",\\"integrity\\":\\"345\\"}}}}"`;
 
 exports[`one-app-dev-cdn modules returns a 500 if a request to proxy a module from the module map fails: remote calls from got 1`] = `
 Array [

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -122,8 +122,10 @@ describe('one-app-dev-cdn', () => {
 
   const sanitizeModuleMapForSnapshot = moduleMapString => moduleMapString.replace(
     /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,8}/g,
-    '0.0.0.0:3001'
+    'localhost:3001'
   );
+
+  process.env.HTTP_ONE_APP_DEV_CDN_PORT = 3001;
 
   beforeEach(() => {
     jest
@@ -271,15 +273,15 @@ describe('one-app-dev-cdn', () => {
         modules: {
           'module-b': {
             node: {
-              url: 'http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.node.js',
+              url: 'http://localhost:3001/static/cdn/module-b/1.0.0/module-b.node.js',
               integrity: '123',
             },
             browser: {
-              url: 'http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.browser.js',
+              url: 'http://localhost:3001/static/cdn/module-b/1.0.0/module-b.browser.js',
               integrity: '234',
             },
             legacyBrowser: {
-              url: 'http://0.0.0.0:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js',
+              url: 'http://localhost:3001/static/cdn/module-b/1.0.0/module-b.legacy.browser.js',
               integrity: '345',
             },
           },
@@ -334,7 +336,7 @@ describe('one-app-dev-cdn', () => {
             JSON.stringify({
               ...defaultRemoteMap,
               key: 'not-used-in-development',
-            }).replace(/https:\/\/example.com\//g, 'http://0.0.0.0:3001/static/')
+            }).replace(/https:\/\/example.com\//g, 'http://localhost:3001/static/')
           );
           expect(got.mock.calls[0]).toContain(remoteModuleMapUrl);
         });

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ export default ({
             const remoteModuleMap = JSON.parse(r.body);
 
             const { modules } = remoteModuleMap;
-            const oneAppDevStaticsAddress = `http://${req.headers.host}/static`;
+            const oneAppDevStaticsAddress = `http://localhost:${process.env.HTTP_ONE_APP_DEV_CDN_PORT}/static`;
 
             Object.keys(modules).forEach((moduleName) => {
               const module = modules[moduleName];
@@ -141,7 +141,7 @@ export default ({
         : {},
       (useLocalModules ? getLocalModuleMap({
         pathToModulemap: path.join(localDevPublicPath, 'module-map.json'),
-        oneAppDevCdnAddress: `http://${req.headers.host}`,
+        oneAppDevCdnAddress: `http://localhost:${process.env.HTTP_ONE_APP_DEV_CDN_PORT}`,
       })
         .then(JSON.parse) : {}),
     ])


### PR DESCRIPTION
Instead of req.headers.host, the oneAppDevCdnAddress and oneAppDevStaticsAddress now points to localhost with the dev cdn port. What happens with running it in docker is currently it will point to the docker IP address which is not reachable.