### PR TITLE
fix(package-content): isolated to lib

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-src
-*.tgz
-__tests__
-__mocks__
-.babelrc
-.jest-cache
-test-results
-.eslintignore
-.eslintrc.json

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "Nickolas Oliver <nickolas.oliver@aexp.com> (https://github.com/PixnBits)"
   ],
   "license": "Apache-2.0",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "test:lint": "eslint --ignore-path .eslintignore --ext .js,.snap .",
     "test:unit": "jest",


### PR DESCRIPTION
This PR filters out additional files being packaged in `one-app-dev-cdn` and limits it to the essentials and library.