### PR TITLE
feat(hooks): localModuleBundleNotFound to aid user debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,22 @@ Type: `boolean`
 Default: `false`<br>
 Whether to use `req.headers.host` or `localhost`. Passed as `true` or `false`, defaults to `false` (`localhost`).
 
-**Note**: The `req.headers.host` is useful if your tests use the `one-app-dev-cdn` on a CI environment or containers that 
+**Note**: The `req.headers.host` is useful if your tests use the `one-app-dev-cdn` on a CI environment or containers that
 that require it to be accessible in the network by other containers or servers.
+
+#### `hooks`
+
+Type: `object`
+
+Default: `{}`<br>
+Description
+
+##### `hooks.localModuleBundleNotFound`
+
+Type: `function`
+
+Default: `undefined`
+Description
 
 ### Proxy Support
 

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -661,6 +661,8 @@ describe('one-app-dev-cdn', () => {
         .get('/cdn/module-b/1.0.0/some-langpack.json');
       expect(moduleResponse.status).toBe(501);
     });
+
+    it.todo('calls the localModuleBundleNotFound hook when a local module is not found');
   });
 
   describe('production', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
add a hook `localModuleBundleNotFound` to be used when the filesystem does not have a bundle for a locally-served module

pairs with https://github.com/americanexpress/one-app/pull/963

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
enable https://github.com/americanexpress/one-app/pull/963: one-app to log messages that an expected/required module bundle is missing and what the user should do to resolve the issue

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-dev-cdn users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-dev-cdn?
<!--- Please describe how your changes impacts developers using one-app-dev-cdn. -->
devs can know when a local module bundle was not found