### PR TITLE
fix(cache-modules): stringify object

### DIFF
--- a/__tests__/util/index.spec.js
+++ b/__tests__/util/index.spec.js
@@ -83,7 +83,7 @@ describe('Cache module utils', () => {
       fs.writeFileSync.mockImplementationOnce(() => ({}));
 
       setupCacheFile();
-
+      expect(fs.writeFileSync).toHaveBeenCalledWith(oneAppModuleCachePath, JSON.stringify({}));
       expect(logSpy).toHaveBeenCalledWith(`Successfully created ${oneAppDirectoryPath}`);
       expect(logSpy).toHaveBeenCalledWith(`Creating ${cacheFileName}`);
       expect(logSpy).toHaveBeenCalledWith(`${cacheFileName} created successfully on ${oneAppModuleCachePath}`);

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -36,7 +36,7 @@ export const setupCacheFile = () => {
       console.log(`Successfully created ${oneAppDirectoryPath}`);
       console.log(`Creating ${cacheFileName}`);
       try {
-        fs.writeFileSync(oneAppModuleCachePath, JSON.stringify('{}'));
+        fs.writeFileSync(oneAppModuleCachePath, JSON.stringify({}));
         console.log(`${cacheFileName} created successfully on ${oneAppModuleCachePath}`);
       } catch (err) {
         console.error(`Error creating ${cacheFileName} on ${oneAppModuleCachePath}, \n${err}`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed issue where setUp was stringfied as object
JSON.stringify('{}') --> JSON.stringify({})
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for one-app-dev-cdn users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using one-app-dev-cdn?
<!--- Please describe how your changes impacts developers using one-app-dev-cdn. -->
